### PR TITLE
Authentication improvements

### DIFF
--- a/app/authentication/authenticable_entity.rb
+++ b/app/authentication/authenticable_entity.rb
@@ -2,12 +2,12 @@ class AuthenticableEntity
   MAXIMUM_USEFUL_DATES     = 30.days
   EXPIRATION_DATES         = 2.days
   WARNING_EXPIRATION_DATES = 5.hours
-  RENEW_ID_CHARACTERS      = 32
+  RENEW_ID_CHARACTERS      = 64
   VERIFICATION_CODE_CHARACTERS = 64
 
   class << self
     def generate_access_token(entity)
-      renew_id = Devise.friendly_token(RENEW_ID_CHARACTERS)
+      renew_id = AuthenticationUniqueToken.generate_friendly(RENEW_ID_CHARACTERS)
       payload = { "#{entity.class.name.underscore}_id" => entity.id }
       payload = add_secure_attrs(payload, renew_id, entity)
       { token: AuthenticationTokenManager.encode(payload), renew_id: renew_id }
@@ -22,7 +22,7 @@ class AuthenticableEntity
     end
 
     def verification_code
-      Devise.friendly_token(VERIFICATION_CODE_CHARACTERS)
+      AuthenticationUniqueToken.generate_friendly(VERIFICATION_CODE_CHARACTERS)
     end
 
     private

--- a/app/authentication/authentication_unique_token.rb
+++ b/app/authentication/authentication_unique_token.rb
@@ -4,5 +4,10 @@ class AuthenticationUniqueToken
     def generate
       SecureRandom.hex(16)
     end
+
+    def generate_friendly(length = 32)
+      rlength = (length * 3) / 4
+      SecureRandom.urlsafe_base64(rlength).tr('lIO0', 'sxyz')
+    end
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -17,14 +17,13 @@ module Api
       # TODO: Refactor and remove rubocop exception
       # rubocop:disable Metrics/AbcSize
       def renew
-        if !authentication_manager.warning_expiration_date_reached?
-          render_error('Warning expiration date has not been reached', :forbidden)
-        elsif !authentication_manager.valid_renew_id?(renew_token_params[:renew_id])
+        if !authentication_manager.valid_renew_id?(renew_token_params[:renew_id])
           render_error('Invalid renew_id', :unauthorized)
         elsif !authentication_manager.able_to_renew?
           render_error('Access token is not valid anymore', :unauthorized)
         else
-          access_token = authentication_manager.renew_access_token(current_user)
+          decoded_auth_token = authentication_manager.decoded_auth_token
+          access_token = authentication_manager.renew_access_token(decoded_auth_token)
           render json: { access_token: access_token }, status: :ok
         end
       end


### PR DESCRIPTION
## Summary
* Remove renew before warning validation
* Use 64 chars for renew id token
* Replace Devise#friendly_token with ruby code
