### PR TITLE
User authenticate_request is only skipped when creating user

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      skip_before_action :current_user, :authenticate_request, except: [:show, :update]
+      skip_before_action :current_user, :authenticate_request, only: [:create]
       def me
         render json: current_user
       end


### PR DESCRIPTION
## Summary

- User needs to be authenticated to go to /users/me

## Issue https://github.com/epintos/wbooks-api/issues/53