### PR TITLE
Changed notification information display

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -24,8 +24,9 @@ module Api
 
       def create_notifications(users)
         users.find_each do |user|
-          Notification.create(reason: :created, action_type: comment.class.name,
-                              action_id: comment.id, from: comment.user, to: user)
+          Notification.create(reason: :created, body: comment.content,
+                              action_type: comment.class.name, action_id: comment.id,
+                              from: comment.user, to: user)
         end
       end
 

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,5 +1,5 @@
 class NotificationSerializer < ActiveModel::Serializer
-  attributes :id, :reason, :information, :action_id, :action_type, :read, :created_at
+  attributes :id, :reason, :body, :action_id, :action_type, :read, :created_at
 
   has_one :from, serializer: SimpleUserSerializer
 end

--- a/db/migrate/20170622183618_add_body_to_notifications.rb
+++ b/db/migrate/20170622183618_add_body_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddBodyToNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :notifications, :body, :string
+  end
+end

--- a/db/migrate/20170622183919_remove_information_from_notifications.rb
+++ b/db/migrate/20170622183919_remove_information_from_notifications.rb
@@ -1,0 +1,5 @@
+class RemoveInformationFromNotifications < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :notifications, :information, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619193828) do
+ActiveRecord::Schema.define(version: 20170622183919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,12 +53,12 @@ ActiveRecord::Schema.define(version: 20170619193828) do
     t.integer  "reason",                      null: false
     t.string   "action_type"
     t.integer  "action_id"
-    t.string   "information", default: [],                 array: true
     t.boolean  "read",        default: false
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.integer  "from_id"
     t.integer  "to_id"
+    t.string   "body"
     t.index ["action_type", "action_id"], name: "index_notifications_on_action_type_and_action_id", using: :btree
     t.index ["from_id"], name: "index_notifications_on_from_id", using: :btree
     t.index ["to_id"], name: "index_notifications_on_to_id", using: :btree

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :notification do
     reason { Notification.reasons.keys.sample }
     read false
-    information { Faker::Lorem.words(4) }
     to factory: :user
     action factory: :book
   end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Notification, type: :model do
     Notification.new(
       reason: reason,
       read: read,
-      information: information,
       to: to,
       action: action
     )
@@ -20,7 +19,6 @@ RSpec.describe Notification, type: :model do
 
   let!(:reason) { Notification.reasons.keys.sample }
   let!(:read) { Faker::Boolean.boolean }
-  let!(:information) { Faker::Lorem.words(4) }
   let!(:to) { create(:user) }
   let!(:action) { create(:book) }
 


### PR DESCRIPTION
## Summary

- Deleted information column, added body column for notification information
- Body column contains the content of the notification trigger (e.g. comment's content on a comment notification)
## Issue https://github.com/epintos/wbooks-api/issues/56